### PR TITLE
ci(workflows): pin actions and add timeout to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-actions-only.yml
+++ b/.github/workflows/codeql-actions-only.yml
@@ -21,6 +21,7 @@ jobs:
   analyze:
     name: Analyze GitHub Actions
     runs-on: ubuntu-slim
+    timeout-minutes: 30
     permissions:
       # required for all workflows
       security-events: write
@@ -41,11 +42,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@2152c31696c8409983789c80ab57c4d91465a2fc # v4
         with:
           languages: "actions"
           build-mode: ${{ matrix.build-mode }}
@@ -62,6 +65,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@2152c31696c8409983789c80ab57c4d91465a2fc # v4
         with:
           category: "/language:actions"


### PR DESCRIPTION
## ✨ Overview

This PR enhances the security and reliability of the CodeQL workflow by implementing SHA-pinned action versions and adding timeout protection. These changes follow GitHub Actions security best practices for supply chain attack prevention and workflow stability.

The modifications address three key concerns:
1. **Security hardening**: Pinning actions to specific commit SHAs prevents potential supply chain attacks through compromised action versions
2. **Credential safety**: Disabling credential persistence reduces the risk of accidental credential exposure in subsequent workflow steps
3. **Resource management**: Adding a 30-minute timeout prevents runaway jobs from consuming excessive CI/CD resources

---

## 🔧 Changes

### Core Changes

- [Workflow] `.github/workflows/codeql-actions-only.yml`
  - Pinned `actions/checkout@v4` to commit SHA `08eba0b27e820071cde6df949e0beb9ba4906955`
  - Pinned `github/codeql-action/init@v4` to commit SHA `2152c31696c8409983789c80ab57c4d91465a2fc`
  - Pinned `github/codeql-action/analyze@v4` to commit SHA `2152c31696c8409983789c80ab57c4d91465a2fc`
  - Added `timeout-minutes: 30` to the analyze job
  - Disabled credential persistence with `persist-credentials: false` in checkout step

**Changed files**: 1 file

---

## 📂 Related Issues

No directly related issues found in commit messages.

---

## ✅ Checklist

Please confirm the following before requesting review:

- [ ] Lint checks pass (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

**Security Improvements**:
- SHA pinning ensures the exact version of actions being used, preventing potential supply chain attacks
- Disabling credential persistence follows the principle of least privilege
- All pinned SHAs correspond to the latest v4 versions of respective actions

**Timeout Setting**:
- The 30-minute timeout is appropriate for CodeQL analysis of GitHub Actions workflows, which are typically lightweight
- This prevents resource waste if the job encounters issues during analysis

**Verification**:
- All pinned commit SHAs have been verified to correspond to the official v4 releases
- The workflow structure and permissions remain unchanged
