### PR TITLE
ci(workflows): upgrade gitleaks to 8.30.0 and update workflow tags to r1.0.2

### DIFF
--- a/.github/workflows/ci-common-scan-gitleaks.yml
+++ b/.github/workflows/ci-common-scan-gitleaks.yml
@@ -23,7 +23,7 @@ on:
         required: false
       gitleaks-version:
         type: string
-        default: "8.29.0"
+        default: "8.30.0"
         description: "gitleaks version to install"
         required: false
       fetch-depth:

--- a/.github/workflows/ci-scan-all.yml
+++ b/.github/workflows/ci-scan-all.yml
@@ -30,16 +30,16 @@ jobs:
     name: Actionlint
     permissions:
       contents: read
-    uses: aglabo/.github/.github/workflows/ci-common-lint-actionlint.yml@r1.0.0
+    uses: aglabo/.github/.github/workflows/ci-common-lint-actionlint.yml@r1.0.2
 
   ghalint:
     name: Ghalint
     permissions:
       contents: read
-    uses: aglabo/.github/.github/workflows/ci-common-lint-ghalint.yml@r1.0.0
+    uses: aglabo/.github/.github/workflows/ci-common-lint-ghalint.yml@r1.0.2
 
   scan-gitleaks:
     name: Gitleaks Secret Scan
     permissions:
       contents: read
-    uses: aglabo/.github/.github/workflows/ci-common-scan-gitleaks.yml@r1.0.0
+    uses: aglabo/.github/.github/workflows/ci-common-scan-gitleaks.yml@r1.0.2


### PR DESCRIPTION
## ✨ Overview

This PR upgrades Gitleaks to version 8.30.0 and updates all shared workflow references in `ci-scan-all.yml` from tag r1.0.0 to r1.0.2. The changes ensure the repository uses the latest security scanning tools and maintains consistency across all workflow references.

The motivation behind this change is to keep security tooling up-to-date (Gitleaks 8.30.0 includes latest vulnerability detection patterns) while synchronizing workflow tags to reflect the current stable release of shared workflows.

---

## 🔧 Changes

### Configuration Updates

- [Configuration] `.github/workflows/ci-common-scan-gitleaks.yml` - Updated default gitleaks-version from 8.29.0 to 8.30.0
- [Configuration] `.github/workflows/ci-scan-all.yml` - Updated workflow references from r1.0.0 to r1.0.2 for:
  - Actionlint workflow
  - Ghalint workflow
  - Gitleaks scan workflow

List of key changes:

- [x] Updated workflow configuration files
- [x] Upgraded security tooling version
- [ ] Removed deprecated logic or configs
- [ ] Refactored for clarity/performance

---

## 📂 Related Issues

Related to #7

---

## ✅ Checklist

Please confirm the following before requesting review:

- [ ] Documentation is updated (if applicable)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Descriptions and examples are clear

---

## 💬 Additional Notes

**Version Compatibility**: Gitleaks 8.30.0 is a minor version upgrade and maintains backward compatibility with existing configurations.

**Workflow Tag Update**: The r1.0.2 tag references the latest stable release of shared workflows that includes this Gitleaks version update along with other improvements merged in PRs #8 and #9.
